### PR TITLE
✨ chore: standardize image path and update version to 0.0.5-rc.1

### DIFF
--- a/charts/flink-doris-connector/Chart.yaml
+++ b/charts/flink-doris-connector/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: flink-doris-connector
 description: Helm chart for flink-kubernetes-operator FlinkDeployment CRD.
 type: application
-version: "0.0.4"
+version: "0.0.5-rc.1"
 appVersion: "24.0.1"

--- a/charts/flink-doris-connector/templates/_helpers.tpl
+++ b/charts/flink-doris-connector/templates/_helpers.tpl
@@ -59,6 +59,25 @@ Create robustName that can be used as Kubernetes resource name, and as subdomain
 {{ regexReplaceAll "\\W+" . "-" | replace "_" "-" | lower | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "standardize-digest" -}}
+{{- $digest := . -}}
+{{- if not (hasPrefix "sha256:" $digest) -}}
+{{- $digest = printf "sha256:%s" $digest -}}
+{{- end -}}
+{{- $digest -}}
+{{- end -}}
+
+{{/*
+Create the path of the operator image to use
+*/}}
+{{- define "flink.imagePath" -}}
+{{- if .Values.image.digest }}
+{{- .Values.image.repository }}@{{ include "standardize-digest" .Values.image.digest }}
+{{- else }}
+{{- .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+{{- end }}
+{{- end }}
+
 {{/* Determine if cloud_sql is present */}}
 {{- define "auth_proxy.has_cloud_sql" -}}
 {{- $has_cloud_sql := false -}}

--- a/charts/flink-doris-connector/templates/flink-deployment.yaml
+++ b/charts/flink-doris-connector/templates/flink-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
 spec:
-  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.digest }}@sha256:{{ .Values.image.digest }}{{ end }}"
+  image: {{ include "flink.imagePath" . }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   flinkVersion: {{ .Values.flinkVersion }}
   serviceAccount: {{ default (include "helm-chart.fullname" .) .Values.serviceAccount }}


### PR DESCRIPTION
Add a helper function to standardize image digests and refactor the  image path definition in the deployment template. Update the chart  version to 0.0.5-rc.1 to reflect these changes. This improves  consistency in image handling and prepares for the next release.